### PR TITLE
Expose grpc Async stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 .vscode
 .coverage
 .python-version
+.dmypy.json

--- a/init_gen.py
+++ b/init_gen.py
@@ -91,7 +91,7 @@ class Visitor(ast.NodeVisitor):
         self._in_const: bool = False
 
     def visit_ClassDef(self, node: ast.ClassDef):
-        if self.is_public(node.name) and not node.name.endswith("AsyncStub"):
+        if self.is_public(node.name):
             self.symbols.append(node.name)
 
     def is_public(self, name: str) -> bool:

--- a/src/aserto/authorizer/v2/__init__.py
+++ b/src/aserto/authorizer/v2/__init__.py
@@ -2,6 +2,7 @@
 
 from aserto.authorizer.v2.authorizer_pb2_grpc import (
     AuthorizerStub,
+    AuthorizerAsyncStub,
     AuthorizerServicer,
 )
 
@@ -29,6 +30,7 @@ from aserto.authorizer.v2.authorizer_pb2 import (
 
 __all__ = [
     "AuthorizerStub",
+    "AuthorizerAsyncStub",
     "AuthorizerServicer",
     "PathSeparator",
     "TraceLevel",


### PR DESCRIPTION
They were labeled "experimental" in previous versions and didn't actually work without explicitly enabling them.
Now they appear to finally be first-class citizens.